### PR TITLE
✨ Add：マイページの作成

### DIFF
--- a/app/controllers/shortcuts_controller.rb
+++ b/app/controllers/shortcuts_controller.rb
@@ -4,11 +4,14 @@ class ShortcutsController < ApplicationController
   before_action :ensure_user, only: [:edit, :update]
 
   def index
-    @shortcuts = Shortcut.includes(:user)
+    @shortcuts = Shortcut.includes(:user).where(status: :published).order(created_at: :desc)
   end
 
   def show
     @shortcut = Shortcut.find(params[:id])
+    if @shortcut.status != "published"
+      redirect_to shortcuts_path
+    end
   end
 
   def new
@@ -48,7 +51,17 @@ class ShortcutsController < ApplicationController
   def destroy
     shortcut = current_user.shortcuts.find(params[:id])
     shortcut.destroy!
-    redirect_to shortcuts_path
+    redirect_to mypage_path
+  end
+
+  def archived
+    shortcut = current_user.shortcuts.find(params[:id])
+    shortcut.status = "archived"
+    if shortcut.save
+      redirect_to mypage_path, notice: "非公開にしました！"
+    else
+      redirect_to mypage_path, alert: "エラーが発生しました"
+    end
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,16 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!, only: [:mypage]
+
   def show
     @user = User.find_by(uid: params[:uid])
-    @shortcuts = @user.shortcuts.where(status: :published)
+    if @user === current_user
+      @shortcuts = @user.shortcuts.all.order(created_at: :desc)
+    else
+      @shortcuts = @user.shortcuts.where(status: :published).order(created_at: :desc)
+    end
+  end
+
+  def mypage
+    redirect_to user_path(current_user)
   end
 end

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,9 +1,6 @@
 <h1>ホーム</h1>
 <% if user_signed_in? %>
-    <p>名前：<%= current_user.name %></p>
-    <p>UID：<%= current_user.uid %></p>
-    <p>メール：<%= current_user.email %></p>
-    <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "btn btn-error" %>
+    ログイン済
 <% else %>
     未ログイン
 <% end %>

--- a/app/views/shared/_dock.html.erb
+++ b/app/views/shared/_dock.html.erb
@@ -16,8 +16,10 @@
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5"><path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" /></svg>
         <p class="text-[10px]">検索</p>
     <% end %>
-    <%= link_to root_path, class: "flex flex-col justify-items-start items-center pt-1" do %>
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5"><path stroke-linecap="round" stroke-linejoin="round" d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" /></svg>
+    <%= link_to mypage_path, class: "flex flex-col justify-items-start items-center pt-1" do %>
+        <div class="size-5">
+            <%= image_tag 'user_default_icon.png', class: "rounded-full object-cover aspect-1/1" %>
+        </div>
         <p class="text-[10px]">マイページ</p>
     <% end %>
 </nav>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,7 +9,7 @@
         <%= link_to "フォロー中", root_path, class: "mr-3" %>
         <%= link_to "新規作成", new_shortcut_path, class: "mr-3" %>
         <%= link_to "検索", root_path, class: "mr-3" %>
-        <%= link_to "マイページ", root_path, class: "mr-3" %>
+        <%= link_to "マイページ", mypage_path, class: "mr-3" %>
     </div>
     <% if user_signed_in? %>
     <% else %>

--- a/app/views/shortcuts/show.html.erb
+++ b/app/views/shortcuts/show.html.erb
@@ -85,8 +85,3 @@
         </div>
     </div>
 <% end %>
-
-<% if user_signed_in? && @shortcut.user == current_user %>
-    <%= link_to "編集", edit_shortcut_path, data: {"turbolinks" => false} %>
-    <%= link_to "削除", shortcut_path, data: { turbo_method: :delete, turbo_confirm: "削除してよろしいですか？" } %>
-<% end %>

--- a/app/views/users/_shortcut.html.erb
+++ b/app/views/users/_shortcut.html.erb
@@ -1,8 +1,62 @@
 <div class="flex flex-col justify-between rounded-xl shadow-sm bg-white">
-    <%= link_to shortcut_path(shortcut) do %>
-        <div class="aspect-16/7 flex justify-center items-center p-3 bg-teal-500 rounded-t-xl">
-            <%= image_tag "icon1.svg", class: "size-8" %>
+    <% if shortcut.status === 'published' %>
+        <%= link_to shortcut_path(shortcut) do %>
+            <div class="aspect-16/7 flex justify-center items-center p-3 bg-teal-500 rounded-t-xl">
+                <%= image_tag "icon1.svg", class: "size-8" %>
+            </div>
+            <h2 class="text-base p-2"><%= shortcut.title %></h2>
+        <% end %>
+    <% elsif shortcut.status === 'draft' %>
+        <div>
+            <div class="aspect-16/7 flex justify-center items-center p-3 bg-zinc-500 rounded-t-xl">
+                <%= image_tag "icon1.svg", class: "size-8" %>
+            </div>
+            <h2 class="text-base p-2"><%= shortcut.title %></h2>
         </div>
-        <h2 class="text-base p-2"><%= shortcut.title %></h2>
+    <% elsif shortcut.status === 'archived' %>
+        <div>
+            <div class="aspect-16/7 flex justify-center items-center p-3 bg-zinc-300 rounded-t-xl">
+                <%= image_tag "icon1.svg", class: "size-8" %>
+            </div>
+            <h2 class="text-base p-2"><%= shortcut.title %></h2>
+        </div>
+    <% end %>
+    <% if user_signed_in? && @user == current_user %>
+        <div class="flex justify-between items-end p-2 pt-0">
+            <% if shortcut.status === 'draft' %>
+                <div class="bg-zinc-500 rounded-full flex items-center px-2 py-[2px]">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-3 stroke-white mr-1">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+                    </svg>
+                    <p class="text-zinc-100 font-bold text-[10px]"><%= shortcut.status %></p>
+                </div>
+            <% elsif shortcut.status === 'published' %>
+                <div class="bg-teal-500 rounded-full flex items-center px-2 py-[2px]">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-3 stroke-white mr-1">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 0 1 3 12c0-1.605.42-3.113 1.157-4.418" />
+                    </svg>
+                    <p class="text-zinc-100 font-bold text-[10px]"><%= shortcut.status %></p>
+                </div>
+            <% elsif shortcut.status === 'archived' %>
+                <div class="border border-zinc-700 border-dashed rounded-full flex items-center px-[6px] py-0">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-3 stroke-zinc-700 mr-1">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88" />
+                    </svg>
+                    <p class="text-zinc-700 font-bold text-[10px]"><%= shortcut.status %></p>
+                </div>
+            <% end %>
+            <div class="dropdown dropdown-top dropdown-end">
+                <div tabindex="0" role="button" class="flex justify-center items-center size-8 rounded-full shadow-sm border border-zinc-200">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M6.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM12.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM18.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z" /></svg>
+                </div>
+                <div tabindex="0" class="flex flex-col items-center dropdown-content menu bg-white border border-zinc-200 rounded-box z-1 w-28 mb-1 p-1 shadow-sm divide-y divide-zinc-300">
+                    <%= link_to '削除する', shortcut_path(shortcut), class: "w-full text-rose-500 font-bold p-1", data: { turbo_method: :delete, turbo_confirm: "削除してよろしいですか？" } %>
+                    <% if shortcut.status == 'published' %>
+                        <%= link_to '非公開にする', archived_shortcut_path(shortcut), class: "w-full p-1" %>
+                    <% end %>
+                    <%= link_to '編集する', edit_shortcut_path(shortcut), class: "w-full p-1" %>
+                </div>
+            </div>
+        </div>
     <% end %>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,47 +1,85 @@
-<div class="p-3 pb-1">
-    <div class="grid grid-cols-4 gap-4 bg-white rounded-xl shadow-sm p-3 pt-3 pb-6">
-        <div class="col-span-1 mt-2">
-            <%= image_tag 'user_default_icon.png', class: "rounded-full object-cover aspect-1/1" %>
-        </div>
-        <div class="col-span-3">
-            <div class="flex justify-end mb-1">
-                <% if user_signed_in? && @user == current_user %>
-                    <%= link_to '編集する', user_path(current_user), class: "flex-none px-2 py-[6px] font-bold ml-2 bg-zinc-700 text-white text-[12px] text-center rounded-full" %>
-                <% else %>
-                    <%= link_to 'フォローする', user_path(current_user), class: "px-2 py-[6px] border border-zinc-700 rounded-full text-xs text-zinc-700 align-center font-bold" %>
-                <% end %>
+<div class="flex flex-col items-center">
+    <div class="w-full sm:max-w-2xl p-3 pb-1">
+        <div class="grid grid-cols-4 gap-4 bg-white rounded-xl shadow-sm p-2 pl-3 pb-5">
+            <div class="col-span-1 mt-4 sm:max-w-25">
+                <%= image_tag 'user_default_icon.png', class: "rounded-full object-cover aspect-1/1" %>
             </div>
-            <p class="mb-4"><%= @user.name %></p>
-            <div class="grid grid-cols-3">
-                <div class="col-span-1 flex flex-col items-start">
-                    <div class="flex flex-col items-center">
-                        999
-                        <p class="text-[10px]">投稿</p>
-                    </div>
+            <div class="col-span-3">
+                <div class="flex justify-end mb-1">
+                    <% if user_signed_in? && @user == current_user %>
+                        <div class="dropdown dropdown-end">
+                            <div tabindex="0" role="button" class="flex justify-center items-center size-8 rounded-full shadow-sm border border-zinc-200">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M6.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM12.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM18.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z" /></svg>
+                            </div>
+                            <div tabindex="0" class="flex flex-col items-center dropdown-content menu bg-white border border-zinc-200 rounded-box z-1 w-28 mt-1 p-1 shadow-sm divide-y divide-zinc-300">
+                                <%= link_to '編集する', user_path(current_user), class: "p-2" %>
+                                <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "p-2 text-rose-500" %>
+                            </div>
+                        </div>
+                    <% else %>
+                        <%= link_to 'フォローする', root_path, class: "px-2 py-[6px] border border-zinc-700 rounded-full text-xs text-zinc-700 align-center font-bold" %>
+                    <% end %>
                 </div>
-                <div class="col-span-1 flex flex-col items-start">
-                    <div class="flex flex-col items-center">
-                        999
-                        <p class="text-[10px]">フォロー</p>
+                <p><%= @user.name %></p>
+                <p class="mb-5 text-xs text-zinc-500">@<%= @user.uid %></p>
+                <div class="grid grid-cols-3">
+                    <div class="col-span-1 flex flex-col items-start">
+                        <div class="flex flex-col items-center">
+                            999
+                            <p class="text-[10px]">投稿</p>
+                        </div>
                     </div>
-                </div>
-                <div class="col-span-1 flex flex-col items-start">
-                    <div class="flex flex-col items-center">
-                        999
-                        <p class="text-[10px]">フォロワー</p>
+                    <div class="col-span-1 flex flex-col items-start">
+                        <div class="flex flex-col items-center">
+                            999
+                            <p class="text-[10px]">フォロー</p>
+                        </div>
+                    </div>
+                    <div class="col-span-1 flex flex-col items-start">
+                        <div class="flex flex-col items-center">
+                            999
+                            <p class="text-[10px]">フォロワー</p>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
 
-<div class="mt-1 p-4">
-    <% if @shortcuts.present? %>
-        <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
-            <%= render partial: 'users/shortcut', collection: @shortcuts %>
+
+    <% if user_signed_in? && @user == current_user %>
+        <div class="w-full sm:max-w-2xl grid grid-cols-3 gap-3 px-3 py-2 bg-teal-50 sticky z-50 top-0">
+            <%= link_to mypage_path, class: "flex flex-col items-center rounded-xl bg-white shadow-sm p-4", remote: true do %>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 fill-teal-200">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 1.5H8.25A2.25 2.25 0 0 0 6 3.75v16.5a2.25 2.25 0 0 0 2.25 2.25h7.5A2.25 2.25 0 0 0 18 20.25V3.75a2.25 2.25 0 0 0-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3" />
+                </svg>
+                <p class="text-[10px] mt-3 font-bold">ショートカット</p>
+            <% end %>
+            <%= link_to mypage_path, class: "flex flex-col items-center rounded-xl bg-zinc-100 p-4", remote: true do %>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="stroke-zinc-500 size-6">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" />
+                </svg>
+                <p class="text-[10px] mt-3 text-zinc-500">保存した投稿</p>
+            <% end %>
+            <%= link_to mypage_path, class: "flex flex-col items-center rounded-xl bg-zinc-100 p-4", remote: true do %>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="stroke-zinc-500 size-6">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
+                </svg>
+                <p class="text-[10px] mt-3 text-zinc-500">アナリティクス</p>
+            <% end %>
         </div>
-    <% else %>
-        <p>作成したショートカットはありません</p>
     <% end %>
+
+    <div class="w-full sm:max-w-2xl p-3">
+        <div class="flex justify-between items-center mb-5">
+            <p class="text-xl font-bold">ショートカット</p>
+        </div>
+        <% if @shortcuts.present? %>
+            <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
+                <%= render partial: 'users/shortcut', collection: @shortcuts %>
+            </div>
+        <% else %>
+            <p>作成したショートカットはありません</p>
+        <% end %>
+    </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,12 @@ Rails.application.routes.draw do
     registrations: 'users/registrations'
   }
   resources :users, param: :uid, only: [:show]
-  resources :shortcuts
+  get "mypage" => "users#mypage"
+  resources :shortcuts do
+    member do
+      get :archived
+    end
+  end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
Closes #22 

# 概要
マイページの実装

## 内容
- 自分が作成したすべてのショートカットを表示
- 作成したショートカットの編集画面へ遷移
- 公開中のショートカットを非公開ステータスへ変更可能に
- 作成したショートカットをマイページから削除できるように
- マイページからログアウトできるように