### PR TITLE
✨ Add：ユーザーのアイコンの設定機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem "bootsnap", require: false
 # gem "image_processing", "~> 1.2"
 
 gem "devise"
+gem "active_storage_validations"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,12 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_storage_validations (2.0.2)
+      activejob (>= 6.1.4)
+      activemodel (>= 6.1.4)
+      activestorage (>= 6.1.4)
+      activesupport (>= 6.1.4)
+      marcel (>= 1.0.3)
     activejob (7.2.2.1)
       activesupport (= 7.2.2.1)
       globalid (>= 0.3.6)
@@ -319,6 +325,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  active_storage_validations
   bootsnap
   brakeman
   capybara

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,6 +15,7 @@ class UsersController < ApplicationController
   end
 
   def update
+    @user.avatar.attach(params[:user][:avatar]) if @user.avatar.blank?
     if @user.update(user_params)
       redirect_to mypage_path
     else
@@ -34,7 +35,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :uid)
+    params.require(:user).permit(:name, :uid, :avatar)
   end
 
   def ensure_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,13 +5,18 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable
 
+  has_many :shortcuts, dependent: :destroy
+
+  has_one_attached :avatar
+  validates :avatar, content_type: { in: %w[image/jpeg image/gif image/png],
+                    message: "有効なフォーマットではありません" },
+                    size: { less_than: 5.megabytes, message: " 5MBを超える画像はアップロードできません" }
+
   VALID_UID_REGEX = /\A[a-zA-Z0-9]+\z/
   validates :uid, presence: true, uniqueness: true, length: { minimum:3, maximum: 16 }, format: { with: VALID_UID_REGEX }, on: :update
 
   validates :name, presence: true, uniqueness: true, length: { minimum:3, maximum: 16 }, on: :update
   validates :email, presence: true, uniqueness: { case_insensitive: true }, format: { with: Devise.email_regexp }
-
-  has_many :shortcuts, dependent: :destroy
 
   def to_param
     uid

--- a/app/views/shared/_dock.html.erb
+++ b/app/views/shared/_dock.html.erb
@@ -18,7 +18,11 @@
     <% end %>
     <%= link_to mypage_path, class: "flex flex-col justify-items-start items-center pt-1" do %>
         <div class="size-5">
-            <%= image_tag 'user_default_icon.png', class: "rounded-full object-cover aspect-1/1" %>
+            <% if user_signed_in? && current_user.avatar.present? %>
+                <%= image_tag current_user.avatar, class: "rounded-full object-cover aspect-1/1" %>
+            <% else %>
+                <%= image_tag 'user_default_icon.png', class: "rounded-full object-cover aspect-1/1" %>
+            <% end %>
         </div>
         <p class="text-[10px]">マイページ</p>
     <% end %>

--- a/app/views/shortcuts/_shortcut.html.erb
+++ b/app/views/shortcuts/_shortcut.html.erb
@@ -9,7 +9,11 @@
         <div class="flex justify-between items-center p-2 truncate">
             <%= link_to user_path(shortcut.user), class: "flex items-center " do %>
                 <div class="size-5">
-                    <%= image_tag 'user_default_icon.png', class: "rounded-full object-cover aspect-1/1" %>
+                    <% if shortcut.user.avatar.present? %>
+                        <%= image_tag shortcut.user.avatar, class: "rounded-full object-cover aspect-1/1" %>
+                    <% else %>
+                        <%= image_tag 'user_default_icon.png', class: "rounded-full object-cover aspect-1/1" %>
+                    <% end %>
                 </div>
                 <p class="pl-1 text-xs"><%= shortcut.user.name %></p>
             <% end %>

--- a/app/views/shortcuts/show.html.erb
+++ b/app/views/shortcuts/show.html.erb
@@ -1,7 +1,11 @@
 <div class="flex justify-between items-center bg-white sticky z-40 top-0 p-2 shadow-sm">
     <%= link_to user_path(@shortcut.user), class: "flex items-center " do %>
         <div class="size-6">
-            <%= image_tag 'user_default_icon.png', class: "rounded-full object-cover aspect-1/1" %>
+            <% if @shortcut.user.avatar.present? %>
+                <%= image_tag @shortcut.user.avatar, class: "rounded-full object-cover aspect-1/1" %>
+            <% else %>
+                <%= image_tag 'user_default_icon.png', class: "rounded-full object-cover aspect-1/1" %>
+            <% end %>
         </div>
         <p class="pl-1 text-base"><%= @shortcut.user.name %></p>
     <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,13 +1,22 @@
-<div class="p-3">
-    <div class="rounded-xl bg-white shadow-sm p-3">
-        <%= form_with model: @user, url: user_path, method: :put do |f| %>
+<div class="flex flex-col items-center p-3">
+    <div class="w-full sm:max-w-2xl rounded-xl bg-white shadow-sm p-3">
+        <%= form_with model: @user, url: user_path, method: :put, class: "w-full" do |f| %>
             <div class="flex justify-end">
-                <%= f.submit '保存する', class: "px-2 py-[6px] border border-zinc-700 rounded-full text-xs text-zinc-700 align-center font-bold" %>
+                <%= f.submit '保存する', class: "px-2 py-[6px] bg-teal-500 rounded-full text-xs text-white align-center font-bold" %>
             </div>
             <div class="flex flex-col items-center">
-                <div class="mt-4 max-w-25">
-                    <%= image_tag 'user_default_icon.png', class: "rounded-full object-cover aspect-1/1" %>
+                <div class="max-w-25 relative">
+                    <% if @user.avatar.present? %>
+                        <%= image_tag @user.avatar, class: "rounded-full object-cover aspect-1/1" %>
+                    <% else %>
+                        <%= image_tag 'user_default_icon.png', class: "rounded-full object-cover aspect-1/1" %>
+                    <% end %>
+                    <div id="avatar" class="absolute top-0 left-0 bg-white">
+                        <img id="avatar_preview" class="rounded-full object-cover aspect-1/1">
+                    </div>
                 </div>
+                <%= f.label :avatar, '画像を設定', class: "form-label my-2 px-2 py-[6px] border border-zinc-700 rounded-full text-xs text-zinc-700 align-center font-bold" %>
+                <%= f.file_field :avatar, onchange: "avatarImage(this);", accept: "image/jpeg,image/gif,image/png", class: "hidden" %>
                 <div class="w-full mt-3 p-1">
                     <div class="mb-5">
                         <p>ユーザーネーム</p>
@@ -28,8 +37,19 @@
             </div>
         <% end %>
     </div>
-    <div class="flex flex-col items-center mt-8">
+    <div class="sm:max-w-2xl flex flex-col items-center mt-20">
         <%= link_to "アカウントを削除する", user_path, data: { turbo_method: :delete, turbo_confirm: "本当にアカウントを削除しますか？" }, class: "w-full mb-2 p-2 bg-white rounded-full border border-rose-500 text-rose-500 text-center" %>
         <p class="text-rose-500">削除するとすべてのデータが消去されます</p>
     </div>
 </div>
+
+<!------ プレビュー表示用の JavaScript ------->
+<script>
+    function avatarImage(obj){
+        var fileReader = new FileReader();
+        fileReader.onload = (function() {
+        document.querySelector('#avatar_preview').src = fileReader.result;
+        });
+        fileReader.readAsDataURL(obj.files[0]);
+    }
+</script>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,7 +2,11 @@
     <div class="w-full sm:max-w-2xl p-3 pb-1">
         <div class="grid grid-cols-4 gap-4 bg-white rounded-xl shadow-sm p-2 pl-3 pb-5">
             <div class="col-span-1 mt-4 sm:max-w-25">
-                <%= image_tag 'user_default_icon.png', class: "rounded-full object-cover aspect-1/1" %>
+                <% if @user.avatar.present? %>
+                    <%= image_tag @user.avatar, class: "rounded-full object-cover aspect-1/1" %>
+                <% else %>
+                    <%= image_tag 'user_default_icon.png', class: "rounded-full object-cover aspect-1/1" %>
+                <% end %>
             </div>
             <div class="col-span-3">
                 <div class="flex justify-end mb-1">

--- a/db/migrate/20250416074219_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20250416074219_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type, type: :string
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_15_083725) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_16_074219) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.string "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "instructions", force: :cascade do |t|
     t.string "shortcut_id", null: false
@@ -48,6 +76,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_15_083725) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "instructions", "shortcuts"
   add_foreign_key "shortcuts", "users"
 end


### PR DESCRIPTION
Closes #23 

# 概要
ユーザーのアイコンの設定機能の実装

## 内容
- ユーザー編集画面からアイコン画像を設定できるように
- アイコンが設定されている場合、以下の画面にてユーザーのアイコンが表示されるように
   - ショートカット一覧画面の各ショートカットのユーザー名の横
   - ショートカット詳細ページのユーザー名の横
   - スマホ時に表示される下部メニューバーのマイページタブ