### PR TITLE
🐛 Fix：マイページにて非公開ボタンのクリック判定修正

### DIFF
--- a/app/controllers/shortcuts_controller.rb
+++ b/app/controllers/shortcuts_controller.rb
@@ -81,7 +81,7 @@ class ShortcutsController < ApplicationController
     @shortcut = current_user.shortcuts.find(params[:id])
     @shortcut.status = "archived"
     if @shortcut.save
-      render turbo_stream: turbo_stream.replace("shortcut-#{@shortcut.id}", partial: "users/shortcut", locals: { shortcut: @shortcut } )
+      redirect_to mypage_path, notice: "非公開にしました"
     else
       redirect_to mypage_path, alert: "エラーが発生しました"
     end

--- a/app/views/users/_shortcut.html.erb
+++ b/app/views/users/_shortcut.html.erb
@@ -59,7 +59,7 @@
                     <div tabindex="0" class="flex flex-col items-center dropdown-content menu bg-white border border-zinc-200 rounded-box z-1 w-28 mb-1 p-1 shadow-sm divide-y divide-zinc-300">
                         <%= link_to '削除する', shortcut_path(shortcut), class: "w-full text-rose-500 font-bold p-1", data: { turbo_method: :delete, turbo_confirm: "削除してよろしいですか？" } %>
                         <% if shortcut.status == 'published' %>
-                            <%= link_to '非公開にする', archived_shortcut_path(shortcut), class: "w-full p-1" %>
+                            <%= link_to '非公開にする', archived_shortcut_path(shortcut), class: "w-full p-1", data: { turbo: false } %>
                         <% end %>
                         <%= link_to '編集する', edit_shortcut_path(shortcut), class: "w-full p-1", data: { turbo: false } %>
                     </div>


### PR DESCRIPTION
# 概要
マイページにて非公開ボタンのクリック判定修正

## 内容
マイページで自分が作成したショートカットを非公開にするボタンが、クリックしていなくても、マウスをホバーした時に勝手にクリック判定されて非公開になってしまうバグを修正