### PR TITLE
✨ 独自ドメインの反映

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,12 +77,12 @@ Rails.application.configure do
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.
   config.action_mailer.perform_caching = false
-  config.action_mailer.default_url_options = { host: "shortcuthub.onrender.com" }
+  config.action_mailer.default_url_options = { host: "shortcuthub.jp" }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     address:              "smtp.gmail.com",
     port:                 587,
-    domain:               "shortcuthub.onrender.com",
+    domain:               "shortcuthub.jp",
     user_name:            Rails.application.credentials.gmail[:user_name],
     password:             Rails.application.credentials.gmail[:password],
     authentication:       :login,
@@ -110,4 +110,5 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.hosts << 'shortcuthub.jp'
 end


### PR DESCRIPTION
Closes #40 

# 概要
独自ドメイン反映

## 内容
- xserverにて『shortcuthub.jp』のドメインを取得し、DNSレコード設定
- （旧）shortcuthub.onrender.com　→　（新）shortcuthub.jp