### PR TITLE
✨ Add：ユーザー削除をモーダルで確認

### DIFF
--- a/app/javascript/controllers/delete_user_controller.js
+++ b/app/javascript/controllers/delete_user_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="delete-user"
+export default class extends Controller {
+  static targets = ["modal"]
+
+  show() {
+    this.modalTarget.show();
+  }
+
+  close() {
+    this.modalTarget.close();
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -13,6 +13,9 @@ application.register("autocomplete", AutocompleteController)
 import CommentReplyModalController from "./comment_reply_modal_controller"
 application.register("comment-reply-modal", CommentReplyModalController)
 
+import DeleteUserController from "./delete_user_controller"
+application.register("delete-user", DeleteUserController)
+
 import EditCommentModalController from "./edit_comment_modal_controller"
 application.register("edit-comment-modal", EditCommentModalController)
 
@@ -21,6 +24,9 @@ application.register("edit-reply-modal", EditReplyModalController)
 
 import EditShortcutController from "./edit_shortcut_controller"
 application.register("edit-shortcut", EditShortcutController)
+
+import EditUserIconController from "./edit_user_icon_controller"
+application.register("edit-user-icon", EditUserIconController)
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -37,9 +37,26 @@
             <%= link_to "変更する", user_email_path, class: "flex-none px-2 py-[6px] border border-zinc-700 rounded-full text-xs text-zinc-700 align-center font-bold", data: { turbo: false } %>
         </div>
     </div>
-    <div class="sm:max-w-2xl flex flex-col items-center mt-20">
-        <%= link_to "アカウントを削除する", user_path, data: { turbo_method: :delete, turbo_confirm: "本当にアカウントを削除しますか？" }, class: "w-full mb-2 p-2 bg-white rounded-full border border-rose-500 text-rose-500 text-center" %>
-        <p class="text-rose-500">削除するとすべてのデータが消去されます</p>
+    <div data-controller="delete-user">
+        <div class="sm:max-w-2xl flex flex-col items-center mt-20">
+            <button type="button" class="w-full btn btn-outline btn-error bg-white rounded-full" data-action="click->delete-user#show">アカウントを削除する</button>
+        </div>
+        <dialog class="modal" data-delete-user-target="modal">
+            <div class="modal-box p-4 bg-white">
+                <p class="text-xl font-bold mb-4">アカウントを削除</p>
+                <p class="text-lg mb-4">本当にアカウントを削除しますか？</p>
+                <div class="flex items-end mb-6">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-5 fill-amber-300"><path fill-rule="evenodd" d="M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003ZM12 8.25a.75.75 0 0 1 .75.75v3.75a.75.75 0 0 1-1.5 0V9a.75.75 0 0 1 .75-.75Zm0 8.25a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z" clip-rule="evenodd" /></svg>
+                    <p class="ml-2 text-sm">
+                        削除すると<span class="text-rose-700 font-bold text-sm">すべてのデータが消去されます</span>
+                    </p>
+                </div>
+                <div class="mt-2 grid grid-cols-2 gap-3">
+                    <%= link_to "アカウントを削除する", user_path, data: { turbo_method: :delete, turbo_confirm: "本当にアカウントを削除しますか？" }, class: "col-span-1 py-2 bg-rose-500 rounded-sm text-sm text-white font-bold text-center" %>
+                    <button type="button" class="col-span-1 py-2 border border-zinc-300 rounded-sm text-xs text-zinc-500 font-bold" data-action="click->delete-user#close">閉じる</button>
+                </div>
+            </div>
+        </dialog>
     </div>
 </div>
 


### PR DESCRIPTION
Closes #145 

# 概要
ユーザー削除をモーダルで確認

## 内容
- （旧）ユーザー削除ボタン　→　ダイアログ
- （新）ユーザー削除ボタン　→　モーダルが表示　→　削除ボタンクリック　→　ダイアログ
